### PR TITLE
Adjust github actions config to recognise correct RST pattern for deploying to dev

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - staging
-      - 'RST-test-deploy-dev'
+      - 'RST-*'
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION }}
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   deploy-dev:
-    if: github.ref == 'refs/heads/RST-test-deploy-dev'
+    if: startsWith(github.ref, 'refs/heads/RST-')
     name: Dev - Build & Deploy
     runs-on: windows-2019
     permissions:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -118,7 +118,7 @@ jobs:
           msbuild "Wardship.sln" /p:Configuration=Release /p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="${{ github.workspace }}/WebApp.zip" /p:DeployIisAppPath="Default Web Site"
 
       - name: Publish Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: webapp
           path: ${{ github.workspace }}/WebApp.zip

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - staging
-      - 'RST-*'
+      - 'RST-test-deploy-dev'
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION }}
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   deploy-dev:
-    if: github.ref == 'refs/heads/RST-*'
+    if: github.ref == 'refs/heads/RST-test-deploy-dev'
     name: Dev - Build & Deploy
     runs-on: windows-2019
     permissions:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - staging
-      - 'RST-**'
+      - 'RST-*'
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION }}
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   deploy-dev:
-    if: github.ref == 'refs/heads/RST-**'
+    if: github.ref == 'refs/heads/RST-*'
     name: Dev - Build & Deploy
     runs-on: windows-2019
     permissions:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -53,7 +53,7 @@ jobs:
           msbuild "Wardship.sln" /p:Configuration=Release /p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="${{ github.workspace }}/WebApp.zip" /p:DeployIisAppPath="Default Web Site"
 
       - name: Publish Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: webapp
           path: ${{ github.workspace }}/WebApp.zip
@@ -183,7 +183,7 @@ jobs:
           msbuild "Wardship.sln" /p:Configuration=Release /p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="${{ github.workspace }}/WebApp.zip" /p:DeployIisAppPath="Default Web Site"
 
       - name: Publish Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: webapp
           path: ${{ github.workspace }}/WebApp.zip

--- a/README.cmd
+++ b/README.cmd
@@ -1,1 +1,1 @@
-Updated 21/05/24
+Updated 19/09/24


### PR DESCRIPTION
Adjust github actions to recognise correct RST pattern for build steps (startsWith)